### PR TITLE
allow http_request_errback callback access to exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Or install it yourself as:
               response.send_response
         end
 
+        def http_request_errback e
+          # printing the whole exception
+          puts e.inspect
+        end
+
     end
 
     EM::run do

--- a/lib/em-http-server/server.rb
+++ b/lib/em-http-server/server.rb
@@ -32,7 +32,7 @@ module EventMachine
       rescue Exception => e
         # invoke the method in the user-provided instance
         if respond_to?(:http_request_errback)
-          http_request_errback
+          http_request_errback e
         end
       end
 


### PR DESCRIPTION
Hi

I did some minor changes, to allow debugging and logging of the occurring exceptions if code in process_http_request fails.

Best
