### PR TITLE
Make peer IP address accessible when receiving a request.

### DIFF
--- a/em-http-server.gemspec
+++ b/em-http-server.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "em-http-server"
   gem.require_paths = ["lib"]
-  gem.version       = "0.1.8"
+  gem.version       = "0.1.9"
 
   gem.add_runtime_dependency "eventmachine"
 end

--- a/lib/em-http-server/server.rb
+++ b/lib/em-http-server/server.rb
@@ -30,10 +30,7 @@ module EventMachine
 
         # invoke the method in the user-provided instance
         if respond_to?(:process_http_request)
-          operation = Proc.new do
-            process_http_request
-          end
-          EM.defer(operation, Proc.new{})
+          process_http_request
         end
       rescue Exception => e
         # invoke the method in the user-provided instance

--- a/lib/em-http-server/server.rb
+++ b/lib/em-http-server/server.rb
@@ -25,6 +25,9 @@ module EventMachine
         # save the binary content
         @http_content = content
 
+        # get the ip address of the connected peer
+        @http_ip_address = Socket.unpack_sockaddr_in(get_peername).last
+
         # invoke the method in the user-provided instance
         if respond_to?(:process_http_request)
           operation = Proc.new do

--- a/lib/em-http-server/server.rb
+++ b/lib/em-http-server/server.rb
@@ -27,7 +27,10 @@ module EventMachine
 
         # invoke the method in the user-provided instance
         if respond_to?(:process_http_request)
-          process_http_request
+          operation = Proc.new do
+            process_http_request
+          end
+          EM.defer(operation, Proc.new{})
         end
       rescue Exception => e
         # invoke the method in the user-provided instance

--- a/test/test_app.rb
+++ b/test/test_app.rb
@@ -92,6 +92,13 @@ EORESP
     request_uri = ""
     request_query = ""
     request_method = ""
+    request_http_ip_address = ""
+
+    EventMachine::Connection.class_eval do
+      def get_peername
+        "\x02\x00\xC5\x13\x7F\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00"
+      end
+    end
 
 
     EventMachine.run do
@@ -105,6 +112,7 @@ EORESP
             request_uri = @http_request_uri
             request_query = @http_query_string
             request_http = @http
+            request_http_ip_address = @http_ip_address
           }
         end
       end
@@ -132,6 +140,7 @@ EORESP
     assert_equal( etag, request_http[:if_none_match] )
     assert_equal( nil, request_http[:content_type] )
     assert_equal( "GET", request_method )
+    assert_equal( "127.0.0.1", request_http_ip_address)
   end
 
 


### PR DESCRIPTION
I couldn't find a way to get the IP address of a connection through the parameters and variables provided by the server.  I decided to add a variable that includes the IP address of whatever is connecting to the server.
