### PR TITLE
Fixed annoying warning - `*' interpreted as argument prefix

### DIFF
--- a/lib/em-http-server/response.rb
+++ b/lib/em-http-server/response.rb
@@ -83,7 +83,7 @@ module EventMachine
 			h = (@headers["Set-cookie"] ||= [])
 			if ck.length > 0
 				h.clear
-				add_set_cookie *ck
+				add_set_cookie(*ck)
 			else
 				h
 			end


### PR DESCRIPTION
Tiny fix to eliminate warning when running with flag -w (tested on Ruby 2.3.3)
Similar problem solved here:
https://stackoverflow.com/questions/41821628/ruby-how-can-i-kill-warning-interpreted-as-argument-prefix